### PR TITLE
Memory optimal

### DIFF
--- a/src/BKDataScrape.py
+++ b/src/BKDataScrape.py
@@ -201,7 +201,7 @@ class BKDataScraping:
             VALUES (?, ?, ?, ?, ?)
         '''
         
-        batch_size = 100
+        batch_size = 25
         batch_counter = 0
         
         for store_id in store_ids:
@@ -224,11 +224,12 @@ class BKDataScraping:
                         
                         if item_id.startswith("item_"):
                             cursor.execute(insert_query, (store_id, item_id, price_min, price_max, price_default))
-                            batch_counter += 1
+                
+                batch_counter += 1
                             
-                            if batch_counter >= batch_size:
-                                conn.commit()
-                                batch_counter = 0
+                if batch_counter >= batch_size:
+                    conn.commit()
+                    batch_counter = 0
                             
                                 
             except Exception as e:


### PR DESCRIPTION
After testing on a server, I ran into several memory issues. This was mainly due to holding large amounts of data in lists during scraping operations. 

In the `menu_scraper()` function to preserve memory usage, this has been changed to execute the database with each valid line, along with database commits happening every 25 insertions. 

In the `item_info_scraper()` function to preserve memory usage, the SQL statement was modified to get every `item_id` once as multiple of the same id were discovered.

Ultimately, these help preserve memory usage and allow it to run on devices with 0.5GB of memory. NOTE: This is not recommended if other applications run on the same server!